### PR TITLE
Support for Alignment & Transparency

### DIFF
--- a/OutConsolePicture.psm1
+++ b/OutConsolePicture.psm1
@@ -70,6 +70,12 @@ function Out-ConsolePicture {
             Write-Warning "ISE does not support ANSI colors. No images for you. Sorry! :("
             Break
         }
+		
+		# Ignore Align if Width is not set
+		if(-not $PSBoundParameters.ContainsKey('Width') -and ($Align -ne "Left")){
+			$Align = "Left"
+		}
+
     }
     
     process {
@@ -242,7 +248,7 @@ Renders the image at this specific width. Use of the width parameter overrides D
 .PARAMETER AlphaThreshold
 Default 255; Pixels with an alpha (opacity) value less than this are rendered as fully transparent. Fully opaque = 255. Lowering the value will require a pixel to be more transparent to vanish, and will therefor include more pixels.
 .PARAMETER Align
-Default 'Left'; Align image to the Left, Right, or Center of the terminal.
+Default 'Left'; Align image to the Left, Right, or Center of the terminal. Must be used in conjuction with the Width parameter.
 
 .EXAMPLE
     Out-ConsolePicture ".\someimage.jpg"

--- a/OutConsolePicture.psm1
+++ b/OutConsolePicture.psm1
@@ -20,7 +20,7 @@ function Out-ConsolePicture {
         [switch]$DoNotResize,
 
         [Parameter()]
-        [int]$AlphaThreshold = 0,
+        [int]$AlphaThreshold = 255,
 
         [Parameter()]
         [ValidateSet("Left","Center","Right")]
@@ -240,7 +240,7 @@ By default, images will be resized to have their width match the current console
 .PARAMETER Width
 Renders the image at this specific width. Use of the width parameter overrides DoNotResize.
 .PARAMETER AlphaThreshold
-Default 0; Pixels with an alpha value less than this are rendered as fully transparent. Fully opaque = 255. Start raising above 0 to turn more pixels fully transparent.
+Default 255; Pixels with an alpha (opacity) value less than this are rendered as fully transparent. Fully opaque = 255. Lowering the value will require a pixel to be more transparent to vanish, and will therefor include more pixels.
 .PARAMETER Align
 Default 'Left'; Align image to the Left, Right, or Center of the terminal.
 
@@ -263,4 +263,3 @@ Default 'Left'; Align image to the Left, Right, or Center of the terminal.
     Gloriously coloured console output
 #>
 }
-

--- a/OutConsolePicture.psm1
+++ b/OutConsolePicture.psm1
@@ -220,7 +220,7 @@ function Out-ConsolePicture {
 
 					# Print each line with required padding
 					$color_string.ToString().Split($line_break_char) | % {
-						Write-Host (" "*$padding)$_
+						Write-Host (" "*$padding + $_)
 					}
 				}
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,18 @@ SYNOPSIS
 
 
 SYNTAX
-    Out-ConsolePicture [-Path] <String[]> [-Width <Int32>] [-DoNotResize] [-NoAspectCorrection] [<CommonParameters>]
+    Out-ConsolePicture [-Path] <String[]> [-Width <Int32>] [-DoNotResize] [-AlphaThreshold <Int32>] [-Align <String>] [<CommonParameters>]
 
-    Out-ConsolePicture -Url <Uri[]> [-Width <Int32>] [-DoNotResize] [-NoAspectCorrection] [<CommonParameters>]
+    Out-ConsolePicture -Url <Uri[]> [-Width <Int32>] [-DoNotResize] [-AlphaThreshold <Int32>] [-Align <String>] [<CommonParameters>]
 
-    Out-ConsolePicture -InputObject <Bitmap[]> [-Width <Int32>] [-DoNotResize] [-NoAspectCorrection] [<CommonParameters>]
+    Out-ConsolePicture -InputObject <Bitmap[]> [-Width <Int32>] [-DoNotResize] [-AlphaThreshold <Int32>] [-Align <String>] [<CommonParameters>]
 
 
 DESCRIPTION
-    Out-ConsolePicture will take an image file and convert it to a text string. Colors will be "encoded" using
-    ANSI escape strings. The final result will be output in the shell. By default images will be reformatted
-    to the size of the current shell, though this behaviour can be suppressed with the -DoNotResize switch.
-    ISE users, take note: ISE does not report a window width, and scaling fails as a result. I don't think
-    there is anything I can do about that, so either use the -DoNotResize switch, or don't use ISE.
+    Out-ConsolePicture will take an image file and convert it to a text string. Colors will be "encoded" using ANSI escape strings. The final result will be
+    output in the shell. By default images will be reformatted to the size of the current shell, though this behaviour can be suppressed with the -DoNotResize
+    switch. ISE users, take note: ISE does not report a window width, and scaling fails as a result. I don't think there is anything I can do about that, so
+    either use the -DoNotResize switch, or don't use ISE.
 
 
 PARAMETERS
@@ -73,12 +72,30 @@ PARAMETERS
         Accept wildcard characters?  false
 
     -DoNotResize [<SwitchParameter>]
-        By default, images will be resized to have their width match the current console width. Setting this
-        switch disables that behaviour.
+        By default, images will be resized to have their width match the current console width. Setting this switch disables that behaviour.
 
         Required?                    false
         Position?                    named
         Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -AlphaThreshold <Int32>
+        Default 255; Pixels with an alpha (opacity) value less than this are rendered as fully transparent. Fully opaque = 255. Lowering the value will
+        require a pixel to be more transparent to vanish, and will therefor include more pixels.
+
+        Required?                    false
+        Position?                    named
+        Default value                255
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+
+    -Align <String>
+        Default 'Left'; Align image to the Left, Right, or Center of the terminal. Must be used in conjuction with the Width parameter.
+
+        Required?                    false
+        Position?                    named
+        Default value                Left
         Accept pipeline input?       false
         Accept wildcard characters?  false
 
@@ -99,8 +116,9 @@ OUTPUTS
     -------------------------- EXAMPLE 1 --------------------------
 
     PS > Out-ConsolePicture ".\someimage.jpg"
-
     Renders the image to console
+
+
 
 
 
@@ -108,8 +126,9 @@ OUTPUTS
     -------------------------- EXAMPLE 2 --------------------------
 
     PS > Out-ConsolePicture -Url "http://somewhere.com/image.jpg"
-
     Renders the image to console
+
+
 
 
 
@@ -117,9 +136,10 @@ OUTPUTS
     -------------------------- EXAMPLE 3 --------------------------
 
     PS > $image = New-Object System.Drawing.Bitmap -ArgumentList "C:\myimages\image.png"
-
     $image | Out-ConsolePicture
     Creates a new Bitmap object from a file on disk renders it to the console
+
+
 
 
 


### PR DESCRIPTION
Regarding #4 and #5 I thought I would try understand your code and implement them myself for personal reasons (I wanted to try outputting centered images without big black boxes around images with transparency). What I did ended up working and so I thought I'd toss in a PR just in case you wanted to see the changes :)

Here's a sample of outputting the Super Metroid logo and my pfp to the console
```
Out-ConsolePicture -Url "https://i.imgur.com/QlCLS2W.png" -Width 100 -AlphaThreshold 200 -Align Center
Out-ConsolePicture -Url "https://i.imgur.com/tTmm7sA.png" -Width 32 -AlphaThreshold 100  -Align Center
```
![image](https://user-images.githubusercontent.com/4401999/156867387-a180a00b-e471-4af1-a819-39770405b9b9.png)

Examples of all Alignment options:
![image](https://user-images.githubusercontent.com/4401999/156894445-6571d411-61c0-43ef-8dc3-b769ae875302.png)


The changes were mainly:
- Adding some more comments
- Adding an `Align` parameter (`Left`, `Center`, `Right`) that will align the image in the terminal based on the buffer size
- Adding a `AlphaThreshold` parameter - Default 255; Pixels with an alpha (opacity) value less than this are rendered as fully transparent. Fully opaque = 0. Lowering the value will require a pixel to be more transparent in order to vanish, and will therefore include more pixels.
- Removed the extraneous newline before each image
- Adding support for the alpha channel in each pixel
  - This was only tricky because you only used `▀` (top-half) characters. However if we're on a pair of lines where the top pixel is transparent but the bottom is not, we can't use `▀` because we can't have background without a foreground, so I added logic to swap to the `▄` (bottom-half) character
